### PR TITLE
Hide awkward implementation detail

### DIFF
--- a/FetchRequests/Sources/CollectionType+SortDescriptors.swift
+++ b/FetchRequests/Sources/CollectionType+SortDescriptors.swift
@@ -31,7 +31,7 @@ public extension Sequence where Iterator.Element: NSObject {
         return sorted(by: descriptors.comparator)
     }
 
-    func sorted(by comparator: Comparator) -> [Iterator.Element] {
+    private func sorted(by comparator: Comparator) -> [Iterator.Element] {
         return sorted { comparator($0, $1) == .orderedAscending }
     }
 }


### PR DESCRIPTION
This method can get picked before the Foundation method, which is super awkward since it's untyped