### PR TITLE
We should use #file, not #filePath

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 All notable changes to this project will be documented in this file.
 `FetchRequests` adheres to [Semantic Versioning](https://semver.org/).
 
+## [3.0.1](https://github.com/crewos/FetchRequests/releases/tag/3.0.1)
+Released on 2020-10-26
+
+* Tweaked logging format
+
 ## [3.0](https://github.com/crewos/FetchRequests/releases/tag/3.0)
 Released on 2020-09-15
 

--- a/FetchRequests.podspec
+++ b/FetchRequests.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = 'FetchRequests'
-  s.version = '3.0'
+  s.version = '3.0.1'
   s.license = 'MIT'
   s.summary = 'NSFetchedResultsController inspired eventing'
   s.homepage = 'https://github.com/crewos/FetchRequests'

--- a/FetchRequests/Sources/Logging.swift
+++ b/FetchRequests/Sources/Logging.swift
@@ -11,23 +11,23 @@ import Foundation
 #if canImport(CocoaLumberjack)
 import CocoaLumberjack
 
-func CWLogDebug(_ message: @autoclosure () -> String, level: DDLogLevel = dynamicLogLevel, context: Int = 0, file: StaticString = #filePath, function: StaticString = #function, line: UInt = #line, tag: Any? = nil, asynchronous async: Bool = true, ddlog: DDLog = DDLog.sharedInstance) {
+func CWLogDebug(_ message: @autoclosure () -> String, level: DDLogLevel = dynamicLogLevel, context: Int = 0, file: StaticString = #file, function: StaticString = #function, line: UInt = #line, tag: Any? = nil, asynchronous async: Bool = true, ddlog: DDLog = DDLog.sharedInstance) {
     DDLogDebug(message(), level: level, context: context, file: file, function: function, line: line, tag: tag, asynchronous: async, ddlog: ddlog)
 }
 
-func CWLogInfo(_ message: @autoclosure () -> String, level: DDLogLevel = dynamicLogLevel, context: Int = 0, file: StaticString = #filePath, function: StaticString = #function, line: UInt = #line, tag: Any? = nil, asynchronous async: Bool = true, ddlog: DDLog = DDLog.sharedInstance) {
+func CWLogInfo(_ message: @autoclosure () -> String, level: DDLogLevel = dynamicLogLevel, context: Int = 0, file: StaticString = #file, function: StaticString = #function, line: UInt = #line, tag: Any? = nil, asynchronous async: Bool = true, ddlog: DDLog = DDLog.sharedInstance) {
     DDLogInfo(message(), level: level, context: context, file: file, function: function, line: line, tag: tag, asynchronous: async, ddlog: ddlog)
 }
 
-func CWLogWarning(_ message: @autoclosure () -> String, level: DDLogLevel = dynamicLogLevel, context: Int = 0, file: StaticString = #filePath, function: StaticString = #function, line: UInt = #line, tag: Any? = nil, asynchronous async: Bool = true, ddlog: DDLog = DDLog.sharedInstance) {
+func CWLogWarning(_ message: @autoclosure () -> String, level: DDLogLevel = dynamicLogLevel, context: Int = 0, file: StaticString = #file, function: StaticString = #function, line: UInt = #line, tag: Any? = nil, asynchronous async: Bool = true, ddlog: DDLog = DDLog.sharedInstance) {
     DDLogWarn(message(), level: level, context: context, file: file, function: function, line: line, tag: tag, asynchronous: async, ddlog: ddlog)
 }
 
-func CWLogVerbose(_ message: @autoclosure () -> String, level: DDLogLevel = dynamicLogLevel, context: Int = 0, file: StaticString = #filePath, function: StaticString = #function, line: UInt = #line, tag: Any? = nil, asynchronous async: Bool = true, ddlog: DDLog = DDLog.sharedInstance) {
+func CWLogVerbose(_ message: @autoclosure () -> String, level: DDLogLevel = dynamicLogLevel, context: Int = 0, file: StaticString = #file, function: StaticString = #function, line: UInt = #line, tag: Any? = nil, asynchronous async: Bool = true, ddlog: DDLog = DDLog.sharedInstance) {
     DDLogVerbose(message(), level: level, context: context, file: file, function: function, line: line, tag: tag, asynchronous: async, ddlog: ddlog)
 }
 
-func CWLogError(_ message: @autoclosure () -> String, level: DDLogLevel = dynamicLogLevel, context: Int = 0, file: StaticString = #filePath, function: StaticString = #function, line: UInt = #line, tag: Any? = nil, asynchronous async: Bool = false, ddlog: DDLog = DDLog.sharedInstance) {
+func CWLogError(_ message: @autoclosure () -> String, level: DDLogLevel = dynamicLogLevel, context: Int = 0, file: StaticString = #file, function: StaticString = #function, line: UInt = #line, tag: Any? = nil, asynchronous async: Bool = false, ddlog: DDLog = DDLog.sharedInstance) {
     DDLogError(message(), level: level, context: context, file: file, function: function, line: line, tag: tag, asynchronous: async, ddlog: ddlog)
 }
 #else

--- a/FetchRequestsTests/Controllers/CollapsibleSectionsFetchedResultsControllerTestCase.swift
+++ b/FetchRequestsTests/Controllers/CollapsibleSectionsFetchedResultsControllerTestCase.swift
@@ -827,7 +827,7 @@ extension CollapsibleSectionsFetchedResultsControllerTestCase {
 }
 
 extension CollapsibleSectionsFetchedResultsControllerTestCase {
-    private func setupControllerForKVO(_ file: StaticString = #filePath, line: UInt = #line) {
+    private func setupControllerForKVO(_ file: StaticString = #file, line: UInt = #line) {
         controller = FetchController(
             request: createFetchRequest(),
             sortDescriptors: [
@@ -1263,13 +1263,13 @@ extension CollapsibleSectionsFetchedResultsControllerTestCase {
 }
 
 private extension CollapsibleSectionsFetchedResultsControllerTestCase {
-    func performFetch(_ objectIDs: [String], file: StaticString = #filePath, line: UInt = #line) throws {
+    func performFetch(_ objectIDs: [String], file: StaticString = #file, line: UInt = #line) throws {
         let objects = objectIDs.compactMap { TestObject(id: $0) }
 
         try performFetch(objects, file: file, line: line)
     }
 
-    func performFetch(_ objects: [TestObject], file: StaticString = #filePath, line: UInt = #line) throws {
+    func performFetch(_ objects: [TestObject], file: StaticString = #file, line: UInt = #line) throws {
         controller.performFetch()
 
         self.fetchCompletion(objects)
@@ -1278,7 +1278,7 @@ private extension CollapsibleSectionsFetchedResultsControllerTestCase {
         XCTAssertEqual(sortedObjects, controller.fetchedObjects, file: file, line: line)
     }
 
-    func getObjectAtIndex(_ index: Int, withObjectID objectID: String, file: StaticString = #filePath, line: UInt = #line) -> TestObject! {
+    func getObjectAtIndex(_ index: Int, withObjectID objectID: String, file: StaticString = #file, line: UInt = #line) -> TestObject! {
         let object = controller.fetchedObjects[index]
 
         XCTAssertEqual(object.id, objectID, file: file, line: line)

--- a/FetchRequestsTests/Controllers/FetchedResultsControllerTestCase.swift
+++ b/FetchRequestsTests/Controllers/FetchedResultsControllerTestCase.swift
@@ -468,7 +468,7 @@ extension FetchedResultsControllerTestCase {
 // MARK: - Observed Events
 
 extension FetchedResultsControllerTestCase {
-    private func setupControllerForKVO(_ file: StaticString = #filePath, line: UInt = #line) {
+    private func setupControllerForKVO(_ file: StaticString = #file, line: UInt = #line) {
         controller = FetchedResultsController(
             request: createFetchRequest(),
             sortDescriptors: [

--- a/FetchRequestsTests/Controllers/FetchedResultsControllerTestHarness.swift
+++ b/FetchRequestsTests/Controllers/FetchedResultsControllerTestHarness.swift
@@ -21,13 +21,13 @@ protocol FetchedResultsControllerTestHarness {
 }
 
 extension FetchedResultsControllerTestHarness {
-    func performFetch(_ objectIDs: [String], file: StaticString = #filePath, line: UInt = #line) throws {
+    func performFetch(_ objectIDs: [String], file: StaticString = #file, line: UInt = #line) throws {
         let objects = objectIDs.compactMap { TestObject(id: $0) }
 
         try performFetch(objects, file: file, line: line)
     }
 
-    func performFetch(_ objects: [TestObject], file: StaticString = #filePath, line: UInt = #line) throws {
+    func performFetch(_ objects: [TestObject], file: StaticString = #file, line: UInt = #line) throws {
         controller.performFetch()
 
         self.fetchCompletion(objects)
@@ -36,7 +36,7 @@ extension FetchedResultsControllerTestHarness {
         XCTAssertEqual(sortedObjects, controller.fetchedObjects, file: file, line: line)
     }
 
-    func getObjectAtIndex(_ index: Int, withObjectID objectID: String, file: StaticString = #filePath, line: UInt = #line) -> TestObject! {
+    func getObjectAtIndex(_ index: Int, withObjectID objectID: String, file: StaticString = #file, line: UInt = #line) -> TestObject! {
         let object = controller.fetchedObjects[index]
 
         XCTAssertEqual(object.id, objectID, file: file, line: line)

--- a/FetchRequestsTests/Controllers/PaginatingFetchedResultsControllerTestCase.swift
+++ b/FetchRequestsTests/Controllers/PaginatingFetchedResultsControllerTestCase.swift
@@ -174,13 +174,13 @@ extension PaginatingFetchedResultsControllerTestCase: FetchedResultsControllerDe
 // MARK: - Helper Functions
 
 private extension PaginatingFetchedResultsControllerTestCase {
-    func performPagination(_ objectIDs: [String], file: StaticString = #filePath, line: UInt = #line) {
+    func performPagination(_ objectIDs: [String], file: StaticString = #file, line: UInt = #line) {
         let objects = objectIDs.compactMap { TestObject(id: $0) }
 
         performPagination(objects, file: file, line: line)
     }
 
-    func performPagination(_ objects: [TestObject], file: StaticString = #filePath, line: UInt = #line) {
+    func performPagination(_ objects: [TestObject], file: StaticString = #file, line: UInt = #line) {
         controller.performPagination()
 
         self.paginationCompletion(objects)


### PR DESCRIPTION
`#filePath` isn't very useful...
This was a bad change from the Xcode 12 work