### PR TITLE
Implement resort()

### DIFF
--- a/FetchRequests/Sources/Associations/ObservableToken.swift
+++ b/FetchRequests/Sources/Associations/ObservableToken.swift
@@ -106,7 +106,7 @@ internal class LegacyKeyValueObserving<Object: NSObject, Value: Any>: NSObject, 
         invalidate()
     }
 
-    //swiftlint:disable:next block_based_kvo
+    // swiftlint:disable:next block_based_kvo
     override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey: Any]?, context: UnsafeMutableRawPointer?) {
         guard let typedObject = object as? Object, typedObject == self.object, keyPath == self.keyPath else {
             return super.observeValue(forKeyPath: keyPath, of: object, change: change, context: context)

--- a/FetchRequests/Sources/BoxedJSON.swift
+++ b/FetchRequests/Sources/BoxedJSON.swift
@@ -68,7 +68,7 @@ public class BoxedJSON: NSObject, NSSecureCoding {
     }
 }
 
-//swiftlint:disable identifier_name
+// swiftlint:disable identifier_name
 
 extension JSON: _ObjectiveCBridgeable {
     public func _bridgeToObjectiveC() -> BoxedJSON {

--- a/FetchRequests/Sources/Controller/CollapsibleSectionsFetchedResultsController.swift
+++ b/FetchRequests/Sources/Controller/CollapsibleSectionsFetchedResultsController.swift
@@ -93,7 +93,7 @@ public class CollapsibleSectionsFetchedResultsController<FetchedObject: Fetchabl
     private var deletedSectionsDuringContentChange: Set<String> = []
     private var previousSectionsDuringContentChange: [CollapsibleResultsSection<FetchedObject>] = []
 
-    //swiftlint:disable:next identifier_name
+    // swiftlint:disable:next identifier_name
     private var collapsedSectionsModifiedDuringContentChange: Set<String> = []
     private var collapsedSectionNames: Set<String> = []
 
@@ -102,7 +102,7 @@ public class CollapsibleSectionsFetchedResultsController<FetchedObject: Fetchabl
     private var sectionNamesCheckedForInitialCollapse: Set<String> = []
     private let sectionConfigCheck: SectionCollapseConfigCheck
 
-    //swiftlint:disable:next weak_delegate
+    // swiftlint:disable:next weak_delegate
     private var delegate: CollapsibleSectionsFetchResultsDelegate<FetchedObject>?
 
     private var sectionConfigs: [String: SectionCollapseConfig] = [:]
@@ -251,9 +251,11 @@ public extension CollapsibleSectionsFetchedResultsController {
 // MARK: - Fetch Methods
 public extension CollapsibleSectionsFetchedResultsController {
     func performFetch(completion: (() -> Void)? = nil) {
-        fetchController.performFetch {
-            completion?()
-        }
+        fetchController.performFetch(completion: completion ?? {})
+    }
+
+    func resort(using newSortDescriptors: [NSSortDescriptor], completion: (() -> Void)? = nil) {
+        fetchController.resort(using: newSortDescriptors, completion: completion ?? {})
     }
 }
 

--- a/FetchRequests/Sources/Controller/FetchedResultsControllerProtocol.swift
+++ b/FetchRequests/Sources/Controller/FetchedResultsControllerProtocol.swift
@@ -29,6 +29,7 @@ public protocol FetchedResultsControllerProtocol {
     var sectionNameKeyPath: SectionNameKeyPath? { get }
 
     func performFetch(completion: @escaping () -> Void)
+    func resort(using newSortDescriptors: [NSSortDescriptor], completion: @escaping () -> Void)
     func reset()
 
     func indexPath(for object: FetchedObject) -> IndexPath?
@@ -39,6 +40,10 @@ public protocol FetchedResultsControllerProtocol {
 public extension FetchedResultsControllerProtocol {
     func performFetch() {
         performFetch(completion: {})
+    }
+
+    func resort(using newSortDescriptors: [NSSortDescriptor]) {
+        resort(using: newSortDescriptors, completion: {})
     }
 
     internal func idealSectionIndex(forSectionName name: String) -> Int {

--- a/FetchRequests/Sources/Controller/FetchedResultsControllerWrapper.swift
+++ b/FetchRequests/Sources/Controller/FetchedResultsControllerWrapper.swift
@@ -42,6 +42,10 @@ extension FetchedResultsControllerWrapper: FetchedResultsControllerProtocol {
         controller.performFetch(completion: completion)
     }
 
+    public func resort(using newSortDescriptors: [NSSortDescriptor], completion: @escaping () -> Void) {
+        controller.resort(using: newSortDescriptors, completion: completion)
+    }
+
     public func reset() {
         controller.reset()
     }

--- a/FetchRequests/Sources/Controller/PausableFetchedResultsController.swift
+++ b/FetchRequests/Sources/Controller/PausableFetchedResultsController.swift
@@ -72,7 +72,7 @@ public class PausableFetchedResultsController<FetchedObject: FetchableObject> {
         }
     }
 
-    //swiftlint:disable:next weak_delegate
+    // swiftlint:disable:next weak_delegate
     private var delegate: PausableFetchResultsDelegate<FetchedObject>?
 
     public init(
@@ -95,6 +95,10 @@ public class PausableFetchedResultsController<FetchedObject: FetchableObject> {
 extension PausableFetchedResultsController: FetchedResultsControllerProtocol {
     public func performFetch(completion: @escaping () -> Void) {
         controller.performFetch(completion: completion)
+    }
+
+    public func resort(using newSortDescriptors: [NSSortDescriptor], completion: @escaping () -> Void) {
+        controller.resort(using: newSortDescriptors, completion: completion)
     }
 
     public func reset() {

--- a/FetchRequests/Tests/Controllers/CollapsibleSectionsFetchedResultsControllerTestCase.swift
+++ b/FetchRequests/Tests/Controllers/CollapsibleSectionsFetchedResultsControllerTestCase.swift
@@ -9,9 +9,9 @@
 import XCTest
 @testable import FetchRequests
 
-//swiftlint:disable force_try implicitly_unwrapped_optional
+// swiftlint:disable force_try implicitly_unwrapped_optional
 
-//swiftlint:disable:next type_name
+// swiftlint:disable:next type_name
 class CollapsibleSectionsFetchedResultsControllerTestCase: XCTestCase {
     typealias FetchController = CollapsibleSectionsFetchedResultsController<TestObject>
 
@@ -439,6 +439,22 @@ extension CollapsibleSectionsFetchedResultsControllerTestCase {
 
         XCTAssertEqual(controller.sections.count, 3)
         XCTAssertEqual(controller.sections[0].allObjects.count, 5)
+    }
+
+    func testResort() {
+        controller = FetchController(
+            request: createFetchRequest(),
+            debounceInsertsAndReloads: false
+        )
+
+        let objectIDs = ["a", "b", "c"]
+
+        try! performFetch(objectIDs)
+
+        controller.resort(using: [NSSortDescriptor(keyPath: \TestObject.id, ascending: false)])
+
+        XCTAssertEqual(controller.sections.count, 1)
+        XCTAssertEqual(controller.sections[0].allFetchedIDs, objectIDs.reversed())
     }
 
     func testAccessByIndexPath() {

--- a/FetchRequests/Tests/Controllers/FetchedResultsControllerTestCase.swift
+++ b/FetchRequests/Tests/Controllers/FetchedResultsControllerTestCase.swift
@@ -9,7 +9,7 @@
 import XCTest
 @testable import FetchRequests
 
-//swiftlint:disable force_try implicitly_unwrapped_optional
+// swiftlint:disable force_try implicitly_unwrapped_optional
 class FetchedResultsControllerTestCase: XCTestCase, FetchedResultsControllerTestHarness {
     private(set) var controller: FetchedResultsController<TestObject>!
 
@@ -61,7 +61,10 @@ class FetchedResultsControllerTestCase: XCTestCase, FetchedResultsControllerTest
     }
 
     func testBasicFetch() {
-        controller = FetchedResultsController(request: createFetchRequest(), debounceInsertsAndReloads: false)
+        controller = FetchedResultsController(
+            request: createFetchRequest(),
+            debounceInsertsAndReloads: false
+        )
 
         let objectIDs = ["a", "b", "c"]
 
@@ -69,6 +72,22 @@ class FetchedResultsControllerTestCase: XCTestCase, FetchedResultsControllerTest
 
         XCTAssertEqual(controller.sections.count, 1)
         XCTAssertEqual(controller.sections[0].fetchedIDs, objectIDs)
+    }
+
+    func testResort() {
+        controller = FetchedResultsController(
+            request: createFetchRequest(),
+            debounceInsertsAndReloads: false
+        )
+
+        let objectIDs = ["a", "b", "c"]
+
+        try! performFetch(objectIDs)
+
+        controller.resort(using: [NSSortDescriptor(keyPath: \TestObject.id, ascending: false)])
+
+        XCTAssertEqual(controller.sections.count, 1)
+        XCTAssertEqual(controller.sections[0].fetchedIDs, objectIDs.reversed())
     }
 
     func testAccessByIndexPath() {

--- a/FetchRequests/Tests/Controllers/FetchedResultsControllerTestHarness.swift
+++ b/FetchRequests/Tests/Controllers/FetchedResultsControllerTestHarness.swift
@@ -10,7 +10,7 @@ import XCTest
 import Foundation
 @testable import FetchRequests
 
-//swiftlint:disable implicitly_unwrapped_optional
+// swiftlint:disable implicitly_unwrapped_optional
 
 protocol FetchedResultsControllerTestHarness {
     associatedtype FetchController: FetchedResultsControllerProtocol where

--- a/FetchRequests/Tests/Controllers/FetchedResultsControllerWrapperTestCase.swift
+++ b/FetchRequests/Tests/Controllers/FetchedResultsControllerWrapperTestCase.swift
@@ -9,7 +9,7 @@
 import XCTest
 @testable import FetchRequests
 
-//swiftlint:disable force_try implicitly_unwrapped_optional
+// swiftlint:disable force_try implicitly_unwrapped_optional
 
 class FetchedResultsControllerWrapperTestCase: XCTestCase, FetchedResultsControllerTestHarness {
     private(set) var controller: FetchedResultsControllerWrapper<TestObject>!
@@ -75,6 +75,30 @@ class FetchedResultsControllerWrapperTestCase: XCTestCase, FetchedResultsControl
         XCTAssertEqual(controller.sections.count, 1)
         XCTAssertEqual(controller.sections[0].fetchedIDs, objectIDs)
         XCTAssertEqual(controller.fetchedObjects.map { $0.id }, objectIDs)
+    }
+
+    func testResort() {
+        var calledClosure = false
+        controller = FetchedResultsControllerWrapper(
+            request: createFetchRequest(),
+            debounceInsertsAndReloads: false
+        ) {
+            calledClosure = true
+        }
+
+        let objectIDs = ["a", "b", "c"]
+
+        try! performFetch(objectIDs)
+
+        XCTAssertTrue(calledClosure)
+
+        calledClosure = false
+
+        controller.resort(using: [NSSortDescriptor(keyPath: \TestObject.id, ascending: false)])
+
+        XCTAssertTrue(calledClosure)
+        XCTAssertEqual(controller.sections.count, 1)
+        XCTAssertEqual(controller.sections[0].fetchedIDs, objectIDs.reversed())
     }
 
     func testWrappedProperties() {

--- a/FetchRequests/Tests/Controllers/PaginatingFetchedResultsControllerTestCase.swift
+++ b/FetchRequests/Tests/Controllers/PaginatingFetchedResultsControllerTestCase.swift
@@ -9,7 +9,7 @@
 import XCTest
 @testable import FetchRequests
 
-//swiftlint:disable force_try implicitly_unwrapped_optional
+// swiftlint:disable force_try implicitly_unwrapped_optional
 
 class PaginatingFetchedResultsControllerTestCase: XCTestCase, FetchedResultsControllerTestHarness {
     private(set) var controller: PaginatingFetchedResultsController<TestObject>!
@@ -72,7 +72,10 @@ class PaginatingFetchedResultsControllerTestCase: XCTestCase, FetchedResultsCont
     }
 
     func testBasicFetch() {
-        controller = PaginatingFetchedResultsController(request: createFetchRequest(), debounceInsertsAndReloads: false)
+        controller = PaginatingFetchedResultsController(
+            request: createFetchRequest(),
+            debounceInsertsAndReloads: false
+        )
 
         let objectIDs = ["a", "b", "c"]
 
@@ -82,8 +85,27 @@ class PaginatingFetchedResultsControllerTestCase: XCTestCase, FetchedResultsCont
         XCTAssertEqual(controller.sections[0].fetchedIDs, objectIDs)
     }
 
+    func testResort() {
+        controller = PaginatingFetchedResultsController(
+            request: createFetchRequest(),
+            debounceInsertsAndReloads: false
+        )
+
+        let objectIDs = ["a", "b", "c"]
+
+        try! performFetch(objectIDs)
+
+        controller.resort(using: [NSSortDescriptor(keyPath: \TestObject.id, ascending: false)])
+
+        XCTAssertEqual(controller.sections.count, 1)
+        XCTAssertEqual(controller.sections[0].fetchedIDs, objectIDs.reversed())
+    }
+
     func testPaginationTriggersLoad() {
-        controller = PaginatingFetchedResultsController(request: createFetchRequest(), debounceInsertsAndReloads: false)
+        controller = PaginatingFetchedResultsController(
+            request: createFetchRequest(),
+            debounceInsertsAndReloads: false
+        )
         controller.setDelegate(self)
 
         // Fetch some objects
@@ -114,7 +136,10 @@ class PaginatingFetchedResultsControllerTestCase: XCTestCase, FetchedResultsCont
     }
 
     func testPaginationDoesNotDisableInserts() {
-        controller = PaginatingFetchedResultsController(request: createFetchRequest(), debounceInsertsAndReloads: false)
+        controller = PaginatingFetchedResultsController(
+            request: createFetchRequest(),
+            debounceInsertsAndReloads: false
+        )
         controller.setDelegate(self)
 
         // Fetch some objects

--- a/FetchRequests/Tests/Controllers/PausableFetchedResultsControllerTestCase.swift
+++ b/FetchRequests/Tests/Controllers/PausableFetchedResultsControllerTestCase.swift
@@ -9,7 +9,7 @@
 import XCTest
 @testable import FetchRequests
 
-//swiftlint:disable force_try implicitly_unwrapped_optional
+// swiftlint:disable force_try implicitly_unwrapped_optional
 
 class PausableFetchedResultsControllerTestCase: XCTestCase, FetchedResultsControllerTestHarness {
     private(set) var controller: PausableFetchedResultsController<TestObject>!
@@ -71,6 +71,22 @@ class PausableFetchedResultsControllerTestCase: XCTestCase, FetchedResultsContro
 
         XCTAssertEqual(controller.sections.count, 1)
         XCTAssertEqual(controller.sections[0].fetchedIDs, objectIDs)
+    }
+
+    func testResort() {
+        controller = PausableFetchedResultsController(
+            request: createFetchRequest(),
+            debounceInsertsAndReloads: false
+        )
+
+        let objectIDs = ["a", "b", "c"]
+
+        try! performFetch(objectIDs)
+
+        controller.resort(using: [NSSortDescriptor(keyPath: \TestObject.id, ascending: false)])
+
+        XCTAssertEqual(controller.sections.count, 1)
+        XCTAssertEqual(controller.sections[0].fetchedIDs, objectIDs.reversed())
     }
 
     func testExpectInsertFromBroadcastNotification() {

--- a/FetchRequests/Tests/TestObject+Associations.swift
+++ b/FetchRequests/Tests/TestObject+Associations.swift
@@ -9,7 +9,7 @@
 import Foundation
 @testable import FetchRequests
 
-//swiftlint:disable implicitly_unwrapped_optional
+// swiftlint:disable implicitly_unwrapped_optional
 
 extension TestObject {
     func tagString() -> String? {

--- a/FetchRequests/simplediff-swift/simplediff.swift
+++ b/FetchRequests/simplediff-swift/simplediff.swift
@@ -69,7 +69,7 @@ func diff<T>(_ before: [T], _ after: [T]) -> [Operation<T>] {
     for index: Int in after.indices {
         let element: T = after[index]
 
-        //swiftlint:disable:next identifier_name
+        // swiftlint:disable:next identifier_name
         var _overlay: [Int: Int] = [:]
          // Element must be in *before* list
         if let elemIndices: [Int] = beforeIndices[element] {


### PR DESCRIPTION
This largely builds upon existing facilities for performFetch().
The only meaningful difference is to not drop enqueued inserts.