### PR TITLE
Swift UI Property Wrappers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ jobs:
     - stage: Example Project
       env:
         - SCHEME="iOS Example"
-        - DESTINATION="name=iPhone 11 Pro"
+        - DESTINATION="name=iPhone 12 Pro"
         - PROJECT="Example/iOS-Example.xcodeproj"
       script:
         - set -o pipefail

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ jobs:
   include:
     - stage: Pod Lint
       script:
-        - pod lib lint --verbose --allow-warnings
+        - pod lib lint --quick --fail-fast --verbose --allow-warnings --skip-tests
     - stage: Example Project
       env:
         - SCHEME="iOS Example"

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ jobs:
   include:
     - stage: Pod Lint
       script:
-        - pod lib lint --quick --fail-fast --verbose --allow-warnings --skip-tests
+        - pod lib lint --quick --fail-fast --verbose --skip-tests
     - stage: Example Project
       env:
         - SCHEME="iOS Example"

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,11 +16,7 @@ script:
   - set -o pipefail
   #- xcodebuild -version
   #- xcodebuild -showsdks
-  - if [ $RUN_TESTS == "YES" ]; then
-      xcodebuild -project "$PROJECT" -scheme "$SCHEME" -destination "$DESTINATION" -configuration Release ONLY_ACTIVE_ARCH=NO ENABLE_TESTABILITY=YES test | xcpretty -c;
-    else
-      xcodebuild -project "$PROJECT" -scheme "$SCHEME" -destination "$DESTINATION" -configuration Release ONLY_ACTIVE_ARCH=NO build | xcpretty -c;
-    fi
+  - xcodebuild -project "$PROJECT" -scheme "$SCHEME" -destination "$DESTINATION" -configuration Release ONLY_ACTIVE_ARCH=NO ENABLE_TESTABILITY=$RUN_TESTS test | xcpretty -c;
 jobs:
   include:
     - stage: Pod Lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ env:
   matrix:
     - SCHEME="FetchRequests-iOS" DESTINATION="name=iPhone 11 Pro"
     - SCHEME="FetchRequests-tvOS" DESTINATION="name=Apple TV 4K"
-    - SCHEME="FetchRequests-watchOS" DESTINATION="name=Apple Watch Series 5 - 44mm" RUN_TESTS="NO"
+    - SCHEME="FetchRequests-watchOS" DESTINATION="name=Apple Watch Series 5 - 44mm"
     - SCHEME="FetchRequests-macOS" DESTINATION="arch=x86_64"
 script:
   - set -o pipefail

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 os: osx
-osx_image: xcode12
+osx_image: xcode12.5
 language: swift
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,9 @@ env:
     - PROJECT=FetchRequests.xcodeproj
     - RUN_TESTS="YES"
   matrix:
-    - SCHEME="FetchRequests-iOS" DESTINATION="name=iPhone 11 Pro"
-    - SCHEME="FetchRequests-tvOS" DESTINATION="name=Apple TV 4K"
-    - SCHEME="FetchRequests-watchOS" DESTINATION="name=Apple Watch Series 5 - 44mm"
+    - SCHEME="FetchRequests-iOS" DESTINATION="name=iPhone 12 Pro"
+    - SCHEME="FetchRequests-tvOS" DESTINATION="name=Apple TV 4K (2nd generation)"
+    - SCHEME="FetchRequests-watchOS" DESTINATION="name=Apple Watch Series 6 - 44mm"
     - SCHEME="FetchRequests-macOS" DESTINATION="arch=x86_64"
 script:
   - set -o pipefail

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 All notable changes to this project will be documented in this file.
 `FetchRequests` adheres to [Semantic Versioning](https://semver.org/).
 
+## [3.2](https://github.com/crewos/FetchRequests/releases/tag/3.2)
+Released on TKTKTK
+
+* Added FetchableRequest SwiftUI Property Wrapper and friends
+
 ## [3.1.1](https://github.com/crewos/FetchRequests/releases/tag/3.1.1)
 Released on 2021-05-19
 

--- a/FetchRequests.podspec
+++ b/FetchRequests.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = 'FetchRequests'
-  s.version = '3.1.1'
+  s.version = '3.2'
   s.license = 'MIT'
   s.summary = 'NSFetchedResultsController inspired eventing'
   s.homepage = 'https://github.com/crewos/FetchRequests'
@@ -28,8 +28,8 @@ Pod::Spec.new do |s|
   s.test_spec do |test_spec|
     test_spec.source_files = 'FetchRequests/Tests/**/*.swift'
 
-    # watchOS inherently doesn't support tests
     test_spec.ios.deployment_target = ios_deployment_target
+    test_spec.watchos.deployment_target = watchos_deployment_target
     test_spec.tvos.deployment_target = tvos_deployment_target
     test_spec.macos.deployment_target = macos_deployment_target
   end

--- a/FetchRequests.xcodeproj/project.pbxproj
+++ b/FetchRequests.xcodeproj/project.pbxproj
@@ -128,6 +128,25 @@
 		47FB8090237CE816008F5438 /* BoxedJSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47FB808E237CE816008F5438 /* BoxedJSON.swift */; };
 		47FB8091237CE816008F5438 /* BoxedJSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47FB808E237CE816008F5438 /* BoxedJSON.swift */; };
 		47FB8092237CE816008F5438 /* BoxedJSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47FB808E237CE816008F5438 /* BoxedJSON.swift */; };
+		6623972F267D034D009B696F /* FetchableRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6623972E267D034D009B696F /* FetchableRequest.swift */; };
+		66239730267D034D009B696F /* FetchableRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6623972E267D034D009B696F /* FetchableRequest.swift */; };
+		66239731267D034D009B696F /* FetchableRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6623972E267D034D009B696F /* FetchableRequest.swift */; };
+		66239732267D034D009B696F /* FetchableRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6623972E267D034D009B696F /* FetchableRequest.swift */; };
+		66239737267D03C0009B696F /* TestObject+FetchableObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 471C50B622C6D337007F73E9 /* TestObject+FetchableObject.swift */; };
+		66239738267D03C0009B696F /* TestObject+FetchRequests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47B31B502330671E00D6EB66 /* TestObject+FetchRequests.swift */; };
+		66239739267D03C0009B696F /* PausableFetchedResultsControllerTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 471C50AE22C6D337007F73E9 /* PausableFetchedResultsControllerTestCase.swift */; };
+		6623973A267D03C0009B696F /* FetchedResultsControllerTestHarness.swift in Sources */ = {isa = PBXBuildFile; fileRef = 471C50B022C6D337007F73E9 /* FetchedResultsControllerTestHarness.swift */; };
+		6623973B267D03C0009B696F /* FetchRequestAssociationTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 471C50B422C6D337007F73E9 /* FetchRequestAssociationTestCase.swift */; };
+		6623973C267D03C0009B696F /* JSONTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47C4ECE42335E969004F16D0 /* JSONTestCase.swift */; };
+		6623973D267D03C0009B696F /* PaginatingFetchedResultsControllerTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 471C50AF22C6D337007F73E9 /* PaginatingFetchedResultsControllerTestCase.swift */; };
+		6623973E267D03C0009B696F /* FetchableObjectProtocolTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 471C50B522C6D337007F73E9 /* FetchableObjectProtocolTestCase.swift */; };
+		6623973F267D03C0009B696F /* FetchedResultsControllerTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 471C50B122C6D337007F73E9 /* FetchedResultsControllerTestCase.swift */; };
+		66239740267D03C0009B696F /* CollapsibleSectionsFetchedResultsControllerTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 471C50AC22C6D337007F73E9 /* CollapsibleSectionsFetchedResultsControllerTestCase.swift */; };
+		66239741267D03C0009B696F /* TestObject+Associations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 471C50B722C6D337007F73E9 /* TestObject+Associations.swift */; };
+		66239742267D03C0009B696F /* LoggingTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47C4ECE823361358004F16D0 /* LoggingTestCase.swift */; };
+		66239743267D03C0009B696F /* FetchedResultsControllerWrapperTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 471C50AD22C6D337007F73E9 /* FetchedResultsControllerWrapperTestCase.swift */; };
+		66239744267D03C0009B696F /* TestObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 471C50B222C6D337007F73E9 /* TestObject.swift */; };
+		66239746267D03C0009B696F /* FetchRequests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 471C506C22C6D0DB007F73E9 /* FetchRequests.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -151,6 +170,13 @@
 			proxyType = 1;
 			remoteGlobalIDString = 47A6ED2E22CA90A20034A854;
 			remoteInfo = "FetchRequests-macOS";
+		};
+		66239735267D03C0009B696F /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 471C506322C6D0DB007F73E9 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 471C506B22C6D0DB007F73E9;
+			remoteInfo = FetchRequests;
 		};
 /* End PBXContainerItemProxy section */
 
@@ -201,6 +227,8 @@
 		47C4ECE823361358004F16D0 /* LoggingTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggingTestCase.swift; sourceTree = "<group>"; };
 		47D33F062334163100E247E4 /* JSON.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSON.swift; sourceTree = "<group>"; };
 		47FB808E237CE816008F5438 /* BoxedJSON.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoxedJSON.swift; sourceTree = "<group>"; };
+		6623972E267D034D009B696F /* FetchableRequest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FetchableRequest.swift; sourceTree = "<group>"; };
+		6623974B267D03C0009B696F /* FetchRequests-watchOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "FetchRequests-watchOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -256,6 +284,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		66239745267D03C0009B696F /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				66239746267D03C0009B696F /* FetchRequests.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -281,6 +317,7 @@
 				47A6ED2C22CA90640034A854 /* FetchRequests-tvOSTests.xctest */,
 				47A6ED4622CA90A20034A854 /* FetchRequests.framework */,
 				47A6ED5D22CA90A40034A854 /* FetchRequests-macOSTests.xctest */,
+				6623974B267D03C0009B696F /* FetchRequests-watchOSTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -317,6 +354,7 @@
 				471C50A822C6D1D6007F73E9 /* Controller */,
 				471C50A922C6D203007F73E9 /* Requests */,
 				471C50AA22C6D244007F73E9 /* Associations */,
+				6623972D267D034D009B696F /* SwiftUI */,
 				471C508822C6D18D007F73E9 /* Logging.swift */,
 				47A6ED7722CAA92F0034A854 /* IndexPath+Convenience.swift */,
 				471C508B22C6D18D007F73E9 /* CollectionType+SortDescriptors.swift */,
@@ -390,6 +428,14 @@
 				471C50B522C6D337007F73E9 /* FetchableObjectProtocolTestCase.swift */,
 			);
 			path = Models;
+			sourceTree = "<group>";
+		};
+		6623972D267D034D009B696F /* SwiftUI */ = {
+			isa = PBXGroup;
+			children = (
+				6623972E267D034D009B696F /* FetchableRequest.swift */,
+			);
+			path = SwiftUI;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -557,6 +603,24 @@
 			productReference = 47A6ED5D22CA90A40034A854 /* FetchRequests-macOSTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
+		66239733267D03C0009B696F /* FetchRequests-watchOSTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 66239748267D03C0009B696F /* Build configuration list for PBXNativeTarget "FetchRequests-watchOSTests" */;
+			buildPhases = (
+				66239736267D03C0009B696F /* Sources */,
+				66239745267D03C0009B696F /* Frameworks */,
+				66239747267D03C0009B696F /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				66239734267D03C0009B696F /* PBXTargetDependency */,
+			);
+			name = "FetchRequests-watchOSTests";
+			productName = FetchRequestsTests;
+			productReference = 6623974B267D03C0009B696F /* FetchRequests-watchOSTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -596,6 +660,7 @@
 				47A6ECFD22CA905A0034A854 /* FetchRequests-tvOS */,
 				47A6ED1722CA90640034A854 /* FetchRequests-tvOSTests */,
 				47A6ECCC22CA8FA80034A854 /* FetchRequests-watchOS */,
+				66239733267D03C0009B696F /* FetchRequests-watchOSTests */,
 			);
 		};
 /* End PBXProject section */
@@ -650,6 +715,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		66239747267D03C0009B696F /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
@@ -691,6 +763,7 @@
 				471C50A222C6D18D007F73E9 /* FetchedResultsController.swift in Sources */,
 				471C50A022C6D18D007F73E9 /* PausableFetchedResultsController.swift in Sources */,
 				471C509C22C6D18D007F73E9 /* CollectionType+SortDescriptors.swift in Sources */,
+				6623972F267D034D009B696F /* FetchableRequest.swift in Sources */,
 				471C50A722C6D18D007F73E9 /* simplediff.swift in Sources */,
 				471C509922C6D18D007F73E9 /* Logging.swift in Sources */,
 				47D33F072334163100E247E4 /* JSON.swift in Sources */,
@@ -737,6 +810,7 @@
 				47A6ECD822CA8FA80034A854 /* FetchedResultsController.swift in Sources */,
 				47A6ECD922CA8FA80034A854 /* PausableFetchedResultsController.swift in Sources */,
 				47A6ECDA22CA8FA80034A854 /* CollectionType+SortDescriptors.swift in Sources */,
+				66239732267D034D009B696F /* FetchableRequest.swift in Sources */,
 				47A6ECDB22CA8FA80034A854 /* simplediff.swift in Sources */,
 				47A6ECDC22CA8FA80034A854 /* Logging.swift in Sources */,
 				47D33F0A2334163100E247E4 /* JSON.swift in Sources */,
@@ -762,6 +836,7 @@
 				47A6ED0922CA905A0034A854 /* FetchedResultsController.swift in Sources */,
 				47A6ED0A22CA905A0034A854 /* PausableFetchedResultsController.swift in Sources */,
 				47A6ED0B22CA905A0034A854 /* CollectionType+SortDescriptors.swift in Sources */,
+				66239731267D034D009B696F /* FetchableRequest.swift in Sources */,
 				47A6ED0C22CA905A0034A854 /* simplediff.swift in Sources */,
 				47A6ED0D22CA905A0034A854 /* Logging.swift in Sources */,
 				47D33F092334163100E247E4 /* JSON.swift in Sources */,
@@ -808,6 +883,7 @@
 				47A6ED3A22CA90A20034A854 /* FetchedResultsController.swift in Sources */,
 				47A6ED3B22CA90A20034A854 /* PausableFetchedResultsController.swift in Sources */,
 				47A6ED3C22CA90A20034A854 /* CollectionType+SortDescriptors.swift in Sources */,
+				66239730267D034D009B696F /* FetchableRequest.swift in Sources */,
 				47A6ED3D22CA90A20034A854 /* simplediff.swift in Sources */,
 				47A6ED3E22CA90A20034A854 /* Logging.swift in Sources */,
 				47D33F082334163100E247E4 /* JSON.swift in Sources */,
@@ -837,6 +913,27 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		66239736267D03C0009B696F /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				66239737267D03C0009B696F /* TestObject+FetchableObject.swift in Sources */,
+				66239738267D03C0009B696F /* TestObject+FetchRequests.swift in Sources */,
+				66239739267D03C0009B696F /* PausableFetchedResultsControllerTestCase.swift in Sources */,
+				6623973A267D03C0009B696F /* FetchedResultsControllerTestHarness.swift in Sources */,
+				6623973B267D03C0009B696F /* FetchRequestAssociationTestCase.swift in Sources */,
+				6623973C267D03C0009B696F /* JSONTestCase.swift in Sources */,
+				6623973D267D03C0009B696F /* PaginatingFetchedResultsControllerTestCase.swift in Sources */,
+				6623973E267D03C0009B696F /* FetchableObjectProtocolTestCase.swift in Sources */,
+				6623973F267D03C0009B696F /* FetchedResultsControllerTestCase.swift in Sources */,
+				66239740267D03C0009B696F /* CollapsibleSectionsFetchedResultsControllerTestCase.swift in Sources */,
+				66239741267D03C0009B696F /* TestObject+Associations.swift in Sources */,
+				66239742267D03C0009B696F /* LoggingTestCase.swift in Sources */,
+				66239743267D03C0009B696F /* FetchedResultsControllerWrapperTestCase.swift in Sources */,
+				66239744267D03C0009B696F /* TestObject.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -854,6 +951,11 @@
 			isa = PBXTargetDependency;
 			target = 47A6ED2E22CA90A20034A854 /* FetchRequests-macOS */;
 			targetProxy = 47A6ED6722CAA6170034A854 /* PBXContainerItemProxy */;
+		};
+		66239734267D03C0009B696F /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 471C506B22C6D0DB007F73E9 /* FetchRequests-iOS */;
+			targetProxy = 66239735267D03C0009B696F /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -924,7 +1026,7 @@
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.crewapp.FetchRequests;
 				PRODUCT_NAME = FetchRequests;
-				SDKROOT = iphoneos;
+				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -997,7 +1099,7 @@
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.crewapp.FetchRequests;
 				PRODUCT_NAME = FetchRequests;
-				SDKROOT = iphoneos;
+				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
@@ -1226,6 +1328,38 @@
 			};
 			name = Release;
 		};
+		66239749267D03C0009B696F /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				INFOPLIST_FILE = FetchRequests/TestsInfo.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.crewapp.FetchRequestsTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TARGETED_DEVICE_FAMILY = 4;
+			};
+			name = Debug;
+		};
+		6623974A267D03C0009B696F /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				INFOPLIST_FILE = FetchRequests/TestsInfo.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.crewapp.FetchRequestsTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TARGETED_DEVICE_FAMILY = 4;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -1297,6 +1431,15 @@
 			buildConfigurations = (
 				47A6ED5B22CA90A40034A854 /* Debug */,
 				47A6ED5C22CA90A40034A854 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		66239748267D03C0009B696F /* Build configuration list for PBXNativeTarget "FetchRequests-watchOSTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				66239749267D03C0009B696F /* Debug */,
+				6623974A267D03C0009B696F /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/FetchRequests.xcodeproj/project.pbxproj
+++ b/FetchRequests.xcodeproj/project.pbxproj
@@ -171,12 +171,12 @@
 			remoteGlobalIDString = 47A6ED2E22CA90A20034A854;
 			remoteInfo = "FetchRequests-macOS";
 		};
-		66239735267D03C0009B696F /* PBXContainerItemProxy */ = {
+		6623974D267D07A1009B696F /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 471C506322C6D0DB007F73E9 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 471C506B22C6D0DB007F73E9;
-			remoteInfo = FetchRequests;
+			remoteGlobalIDString = 47A6ECCC22CA8FA80034A854;
+			remoteInfo = "FetchRequests-watchOS";
 		};
 /* End PBXContainerItemProxy section */
 
@@ -614,7 +614,7 @@
 			buildRules = (
 			);
 			dependencies = (
-				66239734267D03C0009B696F /* PBXTargetDependency */,
+				6623974E267D07A1009B696F /* PBXTargetDependency */,
 			);
 			name = "FetchRequests-watchOSTests";
 			productName = FetchRequestsTests;
@@ -952,10 +952,10 @@
 			target = 47A6ED2E22CA90A20034A854 /* FetchRequests-macOS */;
 			targetProxy = 47A6ED6722CAA6170034A854 /* PBXContainerItemProxy */;
 		};
-		66239734267D03C0009B696F /* PBXTargetDependency */ = {
+		6623974E267D07A1009B696F /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = 471C506B22C6D0DB007F73E9 /* FetchRequests-iOS */;
-			targetProxy = 66239735267D03C0009B696F /* PBXContainerItemProxy */;
+			target = 47A6ECCC22CA8FA80034A854 /* FetchRequests-watchOS */;
+			targetProxy = 6623974D267D07A1009B696F /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 

--- a/FetchRequests.xcodeproj/project.pbxproj
+++ b/FetchRequests.xcodeproj/project.pbxproj
@@ -1026,7 +1026,7 @@
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.crewapp.FetchRequests;
 				PRODUCT_NAME = FetchRequests;
-				SDKROOT = watchos;
+				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -1099,7 +1099,7 @@
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.crewapp.FetchRequests;
 				PRODUCT_NAME = FetchRequests;
-				SDKROOT = watchos;
+				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
@@ -1340,6 +1340,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.crewapp.FetchRequestsTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = watchos;
 				TARGETED_DEVICE_FAMILY = 4;
 			};
 			name = Debug;
@@ -1356,6 +1357,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.crewapp.FetchRequestsTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = watchos;
 				TARGETED_DEVICE_FAMILY = 4;
 			};
 			name = Release;

--- a/FetchRequests.xcodeproj/xcshareddata/xcschemes/FetchRequests-watchOS.xcscheme
+++ b/FetchRequests.xcodeproj/xcshareddata/xcschemes/FetchRequests-watchOS.xcscheme
@@ -57,7 +57,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "47A6ECE622CA900D0034A854"
+               BlueprintIdentifier = "66239733267D03C0009B696F"
                BuildableName = "FetchRequests-watchOSTests.xctest"
                BlueprintName = "FetchRequests-watchOSTests"
                ReferencedContainer = "container:FetchRequests.xcodeproj">

--- a/FetchRequests/Sources/Controller/FetchedResultsControllerProtocol.swift
+++ b/FetchRequests/Sources/Controller/FetchedResultsControllerProtocol.swift
@@ -1,5 +1,5 @@
 //
-//  File.swift
+//  FetchedResultsControllerProtocol.swift
 //  Crew
 //
 //  Created by Adam Lickel on 4/5/17.

--- a/FetchRequests/Sources/Controller/PausableFetchedResultsController.swift
+++ b/FetchRequests/Sources/Controller/PausableFetchedResultsController.swift
@@ -1,5 +1,5 @@
 //
-//  File.swift
+//  PausableFetchedResultsController.swift
 //  Crew
 //
 //  Created by Adam Lickel on 4/5/17.

--- a/FetchRequests/Sources/JSON.swift
+++ b/FetchRequests/Sources/JSON.swift
@@ -35,9 +35,11 @@ public enum JSON {
         } else if let value = value as? [Any] {
             self = .array(value)
         } else if let value = value as? [String: JSON] {
-            self = .dictionary(value.reduce(into: [:]) { memo, kvp in
-                memo[kvp.key] = kvp.value.object
-            })
+            self = .dictionary(
+                value.reduce(into: [:]) { memo, kvp in
+                    memo[kvp.key] = kvp.value.object
+                }
+            )
         } else if let value = value as? [String: Any] {
             self = .dictionary(value)
         } else if let _ = value as? NSNull {

--- a/FetchRequests/Sources/SwiftUI/FetchableRequest.swift
+++ b/FetchRequests/Sources/SwiftUI/FetchableRequest.swift
@@ -1,0 +1,155 @@
+//
+//  FetchableRequest.swift
+//
+//  Created by Adam Lickel on 6/10/21.
+//
+
+import Foundation
+import SwiftUI
+
+@propertyWrapper
+@available(iOS 13, macOS 10.15, tvOS 13, watchOS 6, *)
+public struct SectionedFetchableRequest<FetchedObject: FetchableObject>: DynamicProperty {
+    @FetchableRequest
+    private var base: FetchableResults<FetchedObject>
+
+    public var wrappedValue: SectionedFetchableResults<FetchedObject> {
+        return SectionedFetchableResults(contents: _base.fetchController.sections)
+    }
+
+    public mutating func update() {
+        _base.update()
+    }
+}
+
+@propertyWrapper
+@available(iOS 13, macOS 10.15, tvOS 13, watchOS 6, *)
+public struct FetchableRequest<FetchedObject: FetchableObject>: DynamicProperty {
+    @State
+    public private(set) var wrappedValue = FetchableResults<FetchedObject>()
+
+    @State
+    fileprivate var fetchController: FetchedResultsController<FetchedObject>
+
+    @State
+    private var observer = FetchableRequestObserver<FetchedObject>()
+
+    private let animation: Animation?
+
+    public init(
+        fetchRequest: FetchRequests.FetchRequest<FetchedObject>,
+        sortDescriptors: [NSSortDescriptor] = [],
+        debounceInsertsAndReloads: Bool = true,
+        animation: Animation? = nil
+    ) {
+        let controller = FetchedResultsController(
+            request: fetchRequest,
+            sortDescriptors: sortDescriptors,
+            debounceInsertsAndReloads: debounceInsertsAndReloads
+        )
+
+        self.init(controller: controller, animation: animation)
+    }
+
+    internal init(
+        controller: FetchedResultsController<FetchedObject>,
+        animation: Animation? = nil
+    ) {
+        _fetchController = State(initialValue: controller)
+        self.animation = animation
+    }
+
+    public mutating func update() {
+        _wrappedValue.update()
+        _fetchController.update()
+
+        guard !fetchController.hasFetchedObjects else {
+            return
+        }
+
+        defer {
+            fetchController.performFetch()
+        }
+
+        let controller = fetchController
+        let binding = $wrappedValue
+        let animation = self.animation
+
+        observer.handler = { [weak controller] in
+            guard let controller = controller else {
+                return
+            }
+            withAnimation(animation) {
+                let newVersion = binding.wrappedValue.version + 1
+                binding.wrappedValue = FetchableResults(
+                    contents: controller.fetchedObjects,
+                    version: newVersion
+                )
+            }
+        }
+
+        fetchController.setDelegate(observer)
+    }
+}
+
+public struct FetchableResults<FetchedObject: FetchableObject> {
+    private var contents: [FetchedObject]
+    fileprivate var version: Int
+
+    fileprivate init(
+        contents: [FetchedObject] = [],
+        version: Int = 0
+    ) {
+        self.contents = contents
+
+        // Version forces our view to re-render even if the contents haven't changed
+        // This is necessary because of things like associated values or model updates
+        self.version = version
+    }
+}
+
+public struct SectionedFetchableResults<FetchedObject: FetchableObject> {
+    private let contents: [FetchedResultsSection<FetchedObject>]
+
+    fileprivate init(contents: [FetchedResultsSection<FetchedObject>] = []) {
+        self.contents = contents
+    }
+}
+
+extension FetchableResults: RandomAccessCollection {
+    public var startIndex: Int {
+      return contents.startIndex
+    }
+
+    public var endIndex: Int {
+      return contents.endIndex
+    }
+
+    public subscript (position: Int) -> FetchedObject {
+        return contents[position]
+    }
+}
+
+extension SectionedFetchableResults: RandomAccessCollection {
+    public var startIndex: Int {
+      return contents.startIndex
+    }
+
+    public var endIndex: Int {
+      return contents.endIndex
+    }
+
+    public subscript (position: Int) -> FetchedResultsSection<FetchedObject> {
+        return contents[position]
+    }
+}
+
+private class FetchableRequestObserver<
+    FetchedObject: FetchableObject
+>: FetchedResultsControllerDelegate {
+    var handler: () -> Void = { }
+
+    func controllerDidChangeContent(_ controller: FetchedResultsController<FetchedObject>) {
+        handler()
+    }
+}

--- a/FetchRequests/Tests/TestObject+FetchableObject.swift
+++ b/FetchRequests/Tests/TestObject+FetchableObject.swift
@@ -1,5 +1,5 @@
 //
-//  File.swift
+//  TestObject+FetchableObject.swift
 //  FetchRequests-iOSTests
 //
 //  Created by Adam Lickel on 3/29/19.

--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ It should be possible to further remove those restrictions, and some effort has 
 
 There are two SwiftUI Property Wrappers available for use, `FetchableRequest` and `SectionedFetchableRequest`. These are analagous to CoreData's property wrappers.
 
+The controller will perform a fetch once and only once upon the first view render. After that point, it is dependent upon live update events.
+
 Examples:
 
 ```swift
@@ -85,9 +87,6 @@ struct MembersView: View {
     // ...
 }
 ```
-
-The controller will perform a fetch once and only once upon the first view render.
-After that point, it is dependent upon live update events.
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 FetchRequests is an eventing library inspired by NSFetchedResultsController and written in Swift.
 
-[![Build Status](https://img.shields.io/travis/crewos/FetchRequests/main)](https://travis-ci.org/crewos/FetchRequests)
+[![Build Status](https://img.shields.io/travis/crewos/FetchRequests/main)](https://travis-ci.com/crewos/FetchRequests)
 [![codecov](https://img.shields.io/codecov/c/github/crewos/FetchRequests/main)](https://codecov.io/gh/crewos/FetchRequests)
 [![CocoaPods Compatible](https://img.shields.io/cocoapods/v/FetchRequests)](https://cocoapods.org/pods/FetchRequests)
 [![Carthage Compatible](https://img.shields.io/badge/carthage-compatible-4BC51D)](https://github.com/Carthage/Carthage)
@@ -44,7 +44,7 @@ It should be possible to further remove those restrictions, and some effort has 
 
 ### SwiftUI
 
-There are two SwiftUI Property Wrappers available for use, `FetchableRequest` and `SectionedFetchableRequest`. These are analagous to CoreData's property wrappers. 
+There are two SwiftUI Property Wrappers available for use, `FetchableRequest` and `SectionedFetchableRequest`. These are analagous to CoreData's property wrappers.
 
 Examples:
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ FetchRequests is an eventing library inspired by NSFetchedResultsController and 
 - [x] Animate underlying data changes
 - [x] Fetch associated values in batch
 - [x] Support paginated requests
+- [x] SwiftUI Integration
 - [x] Comprehensive Unit Test Coverage
 
 ## Usage
@@ -40,6 +41,53 @@ The unit tests have in-memory objects, with NotificationCenter eventing.
 
 Today, it is heavily dependent on the Obj-C runtime, as well as Key-Value Observation.
 It should be possible to further remove those restrictions, and some effort has been made to remove them.
+
+### SwiftUI
+
+There are two SwiftUI Property Wrappers available for use, `FetchableRequest` and `SectionedFetchableRequest`. These are analagous to CoreData's property wrappers. 
+
+Examples:
+
+```swift
+struct AllUsersView: View {
+    @FetchableRequest(
+        fetchRequest: FetchRequest(request: User.fetchAll),
+        sortDescriptors: [
+            NSSortDescriptor(
+                key: #keyPath(User.name),
+                ascending: true,
+                selector: #selector(NSString.localizedStandardCompare)
+            ),
+        ]
+    )
+    private var members: FetchableResults<User>
+
+    // ...
+}
+```
+
+For more complicated use cases, you probably will need to write initializers for your view, for example:
+
+```swift
+struct MembersView: View {
+    private let fromID: EntityID
+
+    @FetchableRequest
+    private var members: FetchableResults<Membership>
+
+    func init(fromID: EntityID) {
+        self.fromID = fromID
+        _members = FetchableRequest(
+            fetchRequest: Membership.fetchRequest(from: fromID, toEntityType: .user)
+        )
+    }
+
+    // ...
+}
+```
+
+The controller will perform a fetch once and only once upon the first view render.
+After that point, it is dependent upon live update events.
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ It is best when backed by something like a [WebSocket](https://en.wikipedia.org/
 To get started, you create a `FetchRequest` which explains your data access patterns.
 The `FetchedResultsController` is the interface to access the your data.
 It will automatically cache your associated values for the lifetime of that controller.
-If a memory pressure event occurs, it will release its hold on those objects, allowing them to be deinited.
+If a memory pressure event occurs, it will release its hold on those objects, allowing them to be de-inited.
 
 The example app has an UserDefaults-backed storage mechanism.
 The unit tests have in-memory objects, with NotificationCenter eventing.

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,4 @@
 coverage:
   ignore:
     - "Example"
+    - "FetchRequests/Sources/SwiftUI"


### PR DESCRIPTION
This adds property wrappers for use in SwiftUI.
As this library _currently_ targets iOS 12 and related OSes, nothing conforms to Identifiable.
It's straightforward to do that in your own code.

FetchRequests v4 will target iOS 13 and related OSes.

# Note

There's a lot of commit noise in this PR. That's a side effect of two semi-related things:
* Xcode 12.5 supports watchOS tests, so I have enabled them
* Circle-CI.org is now readonly, so we moved to Circle-CI.com