### PR TITLE
v4: Bump all the versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 ## 4.0
 In Progress
 
+* Updated minimum SDKs to iOS 13 and related OSes
+* Added a Swift 5.5 package definition
+
 ## [3.2.0](https://github.com/crewos/FetchRequests/releases/tag/3.2.0)
 Released on 2021-06-21
 

--- a/FetchRequests.xcodeproj/project.pbxproj
+++ b/FetchRequests.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 50;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -641,7 +641,7 @@
 				};
 			};
 			buildConfigurationList = 471C506622C6D0DB007F73E9 /* Build configuration list for PBXProject "FetchRequests" */;
-			compatibilityVersion = "Xcode 9.3";
+			compatibilityVersion = "Xcode 12.0";
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
@@ -1018,9 +1018,9 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				INFOPLIST_FILE = FetchRequests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
-				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				MARKETING_VERSION = 2.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
+				MARKETING_VERSION = 4.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -1033,10 +1033,10 @@
 				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "";
-				TVOS_DEPLOYMENT_TARGET = 12.0;
+				TVOS_DEPLOYMENT_TARGET = 13.0;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
-				WATCHOS_DEPLOYMENT_TARGET = 5.0;
+				WATCHOS_DEPLOYMENT_TARGET = 6.0;
 			};
 			name = Debug;
 		};
@@ -1092,9 +1092,9 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				INFOPLIST_FILE = FetchRequests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
-				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				MARKETING_VERSION = 2.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
+				MARKETING_VERSION = 4.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.crewapp.FetchRequests;
@@ -1106,11 +1106,11 @@
 				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "";
-				TVOS_DEPLOYMENT_TARGET = 12.0;
+				TVOS_DEPLOYMENT_TARGET = 13.0;
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
-				WATCHOS_DEPLOYMENT_TARGET = 5.0;
+				WATCHOS_DEPLOYMENT_TARGET = 6.0;
 			};
 			name = Release;
 		};

--- a/FetchRequests/Sources/FetchableObject.swift
+++ b/FetchRequests/Sources/FetchableObject.swift
@@ -11,15 +11,6 @@ import Foundation
 /// A class of types that should be fetchable via FetchRequests
 public typealias FetchableObject = NSObject & FetchableObjectProtocol
 
-/// A class of types whose instances hold the value of an entity with stable identity.
-/// This exists purely to support targetting OSes that bundle Swift before v5.1
-public protocol FRIdentifiable {
-    /// A type representing the stable identity of the entity associated with `self`.
-    associatedtype ID: Hashable
-    /// The stable identity of the entity associated with `self`.
-    var id: ID { get }
-}
-
 /// A class of types whose instances hold raw data of that entity
 public protocol RawDataRepresentable {
     associatedtype RawData
@@ -32,7 +23,7 @@ public protocol RawDataRepresentable {
 }
 
 /// A class of types that should be fetchable via FetchRequests
-public protocol FetchableObjectProtocol: AnyObject, FRIdentifiable, RawDataRepresentable
+public protocol FetchableObjectProtocol: AnyObject, Identifiable, RawDataRepresentable
     where ID: Comparable
 {
     /// Has this object been marked as deleted?

--- a/Package@swift-5.5.swift
+++ b/Package@swift-5.5.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.0
+// swift-tools-version:5.5
 
 import PackageDescription
 
@@ -6,6 +6,7 @@ let package = Package(
     name: "FetchRequests",
     platforms: [
         .macOS(.v10_15),
+        .macCatalyst(.v13),
         .iOS(.v13),
         .tvOS(.v13),
         .watchOS(.v6),


### PR DESCRIPTION
Remove `FRIdentifiable` and bump all the versions to iOS 13 and related OSes