### PR TITLE
Maintain original insertion order

### DIFF
--- a/FetchRequests.xcodeproj/project.pbxproj
+++ b/FetchRequests.xcodeproj/project.pbxproj
@@ -7,6 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		2AB9763026A7A8DC0086AA77 /* OrderedSetCompat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AB9762F26A7A8DC0086AA77 /* OrderedSetCompat.swift */; };
+		2AB9763126A7A8DC0086AA77 /* OrderedSetCompat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AB9762F26A7A8DC0086AA77 /* OrderedSetCompat.swift */; };
+		2AB9763226A7A8DC0086AA77 /* OrderedSetCompat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AB9762F26A7A8DC0086AA77 /* OrderedSetCompat.swift */; };
+		2AB9763326A7A8DC0086AA77 /* OrderedSetCompat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AB9762F26A7A8DC0086AA77 /* OrderedSetCompat.swift */; };
 		471C507622C6D0DC007F73E9 /* FetchRequests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 471C506C22C6D0DB007F73E9 /* FetchRequests.framework */; };
 		471C507D22C6D0DC007F73E9 /* FetchRequests.h in Headers */ = {isa = PBXBuildFile; fileRef = 471C506F22C6D0DB007F73E9 /* FetchRequests.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		471C509822C6D18D007F73E9 /* FetchedResultsControllerProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 471C508722C6D18D007F73E9 /* FetchedResultsControllerProtocol.swift */; };
@@ -169,6 +173,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		2AB9762F26A7A8DC0086AA77 /* OrderedSetCompat.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderedSetCompat.swift; sourceTree = "<group>"; };
 		4719618122C6DC6C000BBE6B /* CHANGELOG.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = CHANGELOG.md; sourceTree = "<group>"; };
 		471C506C22C6D0DB007F73E9 /* FetchRequests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = FetchRequests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		471C506F22C6D0DB007F73E9 /* FetchRequests.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FetchRequests.h; sourceTree = "<group>"; };
@@ -344,6 +349,7 @@
 				471C509322C6D18D007F73E9 /* FetchableObject.swift */,
 				47D33F062334163100E247E4 /* JSON.swift */,
 				47FB808E237CE816008F5438 /* BoxedJSON.swift */,
+				2AB9762F26A7A8DC0086AA77 /* OrderedSetCompat.swift */,
 			);
 			path = Sources;
 			sourceTree = "<group>";
@@ -732,6 +738,7 @@
 				471C509822C6D18D007F73E9 /* FetchedResultsControllerProtocol.swift in Sources */,
 				471C509E22C6D18D007F73E9 /* FetchRequestAssociation.swift in Sources */,
 				471C50A222C6D18D007F73E9 /* FetchedResultsController.swift in Sources */,
+				2AB9763026A7A8DC0086AA77 /* OrderedSetCompat.swift in Sources */,
 				471C50A022C6D18D007F73E9 /* PausableFetchedResultsController.swift in Sources */,
 				471C509C22C6D18D007F73E9 /* CollectionType+SortDescriptors.swift in Sources */,
 				6623972F267D034D009B696F /* FetchableRequest.swift in Sources */,
@@ -776,6 +783,7 @@
 				47A6ECD622CA8FA80034A854 /* FetchedResultsControllerProtocol.swift in Sources */,
 				47A6ECD722CA8FA80034A854 /* FetchRequestAssociation.swift in Sources */,
 				47A6ECD822CA8FA80034A854 /* FetchedResultsController.swift in Sources */,
+				2AB9763326A7A8DC0086AA77 /* OrderedSetCompat.swift in Sources */,
 				47A6ECD922CA8FA80034A854 /* PausableFetchedResultsController.swift in Sources */,
 				47A6ECDA22CA8FA80034A854 /* CollectionType+SortDescriptors.swift in Sources */,
 				66239732267D034D009B696F /* FetchableRequest.swift in Sources */,
@@ -800,6 +808,7 @@
 				47A6ED0722CA905A0034A854 /* FetchedResultsControllerProtocol.swift in Sources */,
 				47A6ED0822CA905A0034A854 /* FetchRequestAssociation.swift in Sources */,
 				47A6ED0922CA905A0034A854 /* FetchedResultsController.swift in Sources */,
+				2AB9763226A7A8DC0086AA77 /* OrderedSetCompat.swift in Sources */,
 				47A6ED0A22CA905A0034A854 /* PausableFetchedResultsController.swift in Sources */,
 				47A6ED0B22CA905A0034A854 /* CollectionType+SortDescriptors.swift in Sources */,
 				66239731267D034D009B696F /* FetchableRequest.swift in Sources */,
@@ -844,6 +853,7 @@
 				47A6ED3822CA90A20034A854 /* FetchedResultsControllerProtocol.swift in Sources */,
 				47A6ED3922CA90A20034A854 /* FetchRequestAssociation.swift in Sources */,
 				47A6ED3A22CA90A20034A854 /* FetchedResultsController.swift in Sources */,
+				2AB9763126A7A8DC0086AA77 /* OrderedSetCompat.swift in Sources */,
 				47A6ED3B22CA90A20034A854 /* PausableFetchedResultsController.swift in Sources */,
 				47A6ED3C22CA90A20034A854 /* CollectionType+SortDescriptors.swift in Sources */,
 				66239730267D034D009B696F /* FetchableRequest.swift in Sources */,

--- a/FetchRequests.xcodeproj/project.pbxproj
+++ b/FetchRequests.xcodeproj/project.pbxproj
@@ -7,6 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		2A97F51426A8B43100027D90 /* Collections in Frameworks */ = {isa = PBXBuildFile; productRef = 2A97F51326A8B43100027D90 /* Collections */; };
+		2A97F51726A8B44400027D90 /* Collections in Frameworks */ = {isa = PBXBuildFile; productRef = 2A97F51626A8B44400027D90 /* Collections */; };
+		2A97F51926A8B44B00027D90 /* Collections in Frameworks */ = {isa = PBXBuildFile; productRef = 2A97F51826A8B44B00027D90 /* Collections */; };
+		2A97F51B26A8B44F00027D90 /* Collections in Frameworks */ = {isa = PBXBuildFile; productRef = 2A97F51A26A8B44F00027D90 /* Collections */; };
 		2AB9763026A7A8DC0086AA77 /* OrderedSetCompat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AB9762F26A7A8DC0086AA77 /* OrderedSetCompat.swift */; };
 		2AB9763126A7A8DC0086AA77 /* OrderedSetCompat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AB9762F26A7A8DC0086AA77 /* OrderedSetCompat.swift */; };
 		2AB9763226A7A8DC0086AA77 /* OrderedSetCompat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AB9762F26A7A8DC0086AA77 /* OrderedSetCompat.swift */; };
@@ -225,6 +229,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				2A97F51426A8B43100027D90 /* Collections in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -240,6 +245,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				2A97F51B26A8B44F00027D90 /* Collections in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -247,6 +253,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				2A97F51926A8B44B00027D90 /* Collections in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -262,6 +269,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				2A97F51726A8B44400027D90 /* Collections in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -284,6 +292,13 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		2A97F51526A8B44400027D90 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 		471C506222C6D0DB007F73E9 = {
 			isa = PBXGroup;
 			children = (
@@ -293,6 +308,7 @@
 				471C506E22C6D0DB007F73E9 /* FetchRequests */,
 				471C507922C6D0DC007F73E9 /* Tests */,
 				471C506D22C6D0DB007F73E9 /* Products */,
+				2A97F51526A8B44400027D90 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -469,6 +485,9 @@
 			dependencies = (
 			);
 			name = "FetchRequests-iOS";
+			packageProductDependencies = (
+				2A97F51326A8B43100027D90 /* Collections */,
+			);
 			productName = FetchRequests;
 			productReference = 471C506C22C6D0DB007F73E9 /* FetchRequests.framework */;
 			productType = "com.apple.product-type.framework";
@@ -505,6 +524,9 @@
 			dependencies = (
 			);
 			name = "FetchRequests-watchOS";
+			packageProductDependencies = (
+				2A97F51A26A8B44F00027D90 /* Collections */,
+			);
 			productName = FetchRequests;
 			productReference = 47A6ECE422CA8FA80034A854 /* FetchRequests.framework */;
 			productType = "com.apple.product-type.framework";
@@ -523,6 +545,9 @@
 			dependencies = (
 			);
 			name = "FetchRequests-tvOS";
+			packageProductDependencies = (
+				2A97F51826A8B44B00027D90 /* Collections */,
+			);
 			productName = FetchRequests;
 			productReference = 47A6ED1522CA905A0034A854 /* FetchRequests.framework */;
 			productType = "com.apple.product-type.framework";
@@ -559,6 +584,9 @@
 			dependencies = (
 			);
 			name = "FetchRequests-macOS";
+			packageProductDependencies = (
+				2A97F51626A8B44400027D90 /* Collections */,
+			);
 			productName = FetchRequests;
 			productReference = 47A6ED4622CA90A20034A854 /* FetchRequests.framework */;
 			productType = "com.apple.product-type.framework";
@@ -627,6 +655,9 @@
 				Base,
 			);
 			mainGroup = 471C506222C6D0DB007F73E9;
+			packageReferences = (
+				2A97F51226A8B43100027D90 /* XCRemoteSwiftPackageReference "swift-collections" */,
+			);
 			productRefGroup = 471C506D22C6D0DB007F73E9 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -1417,6 +1448,40 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		2A97F51226A8B43100027D90 /* XCRemoteSwiftPackageReference "swift-collections" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/apple/swift-collections.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.0.4;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		2A97F51326A8B43100027D90 /* Collections */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 2A97F51226A8B43100027D90 /* XCRemoteSwiftPackageReference "swift-collections" */;
+			productName = Collections;
+		};
+		2A97F51626A8B44400027D90 /* Collections */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 2A97F51226A8B43100027D90 /* XCRemoteSwiftPackageReference "swift-collections" */;
+			productName = Collections;
+		};
+		2A97F51826A8B44B00027D90 /* Collections */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 2A97F51226A8B43100027D90 /* XCRemoteSwiftPackageReference "swift-collections" */;
+			productName = Collections;
+		};
+		2A97F51A26A8B44F00027D90 /* Collections */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 2A97F51226A8B43100027D90 /* XCRemoteSwiftPackageReference "swift-collections" */;
+			productName = Collections;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 471C506322C6D0DB007F73E9 /* Project object */;
 }

--- a/FetchRequests.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/FetchRequests.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -2,6 +2,6 @@
 <Workspace
    version = "1.0">
    <FileRef
-      location = "self:FetchRequests.xcodeproj">
+      location = "self:">
    </FileRef>
 </Workspace>

--- a/FetchRequests.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/FetchRequests.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,16 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "swift-collections",
+        "repositoryURL": "https://github.com/apple/swift-collections.git",
+        "state": {
+          "branch": null,
+          "revision": "3426dba9ee5c9f8e4981b0fc9d39a818d36eec28",
+          "version": "0.0.4"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/FetchRequests/Sources/Controller/FetchedResultsController.swift
+++ b/FetchRequests/Sources/Controller/FetchedResultsController.swift
@@ -536,23 +536,12 @@ private extension FetchedResultsController {
         }
 
         performChanges(emitChanges: emitChanges) {
-            stopObserving(object)
-
-            sections[indexPath.section].objects.remove(at: indexPath.item)
-            fetchedObjects.remove(at: fetchIndex)
-            fetchedObjectIDs.remove(object.id)
-
-            notifyDeleting(object, at: indexPath, emitChanges: emitChanges)
-
-            if sections[indexPath.section].numberOfObjects == 0 {
-                let section = sections.remove(at: indexPath.section)
-
-                notifyDeleting(section, at: indexPath.section, emitChanges: emitChanges)
-            }
+            remove(object, atIndex: fetchIndex, emitChanges: emitChanges)
         }
     }
 
     func insert<C: Collection>(_ objects: C, emitChanges: Bool = true) where C.Iterator.Element == FetchedObject {
+        // This is snapshotted because we're about to be off the main thread
         let fetchedObjectIDs = self.fetchedObjectIDs
 
         guard objects.count <= 100 || !Thread.isMainThread else {

--- a/FetchRequests/Sources/Controller/FetchedResultsController.swift
+++ b/FetchRequests/Sources/Controller/FetchedResultsController.swift
@@ -192,7 +192,8 @@ public class FetchedResultsController<FetchedObject: FetchableObject>: NSObject,
 
     public private(set) var hasFetchedObjects: Bool = false
     public private(set) var fetchedObjects: [FetchedObject] = []
-    private var fetchedObjectIDs: Set<FetchedObject.ID> = []
+    private var fetchedObjectIDs: OrderedSet<FetchedObject.ID> = []
+
     private var _indexPathsTable: [FetchedObject: IndexPath]?
     private var indexPathsTable: [FetchedObject: IndexPath] {
         if let existing = _indexPathsTable {
@@ -556,7 +557,7 @@ private extension FetchedResultsController {
 
     private func insert<C: Collection>(
         _ objects: C,
-        fetchedObjectIDs: Set<FetchedObject.ID>,
+        fetchedObjectIDs: OrderedSet<FetchedObject.ID>,
         emitChanges: Bool = true
     ) where C.Iterator.Element == FetchedObject {
         let objects = objects.filter { object in

--- a/FetchRequests/Sources/Controller/FetchedResultsControllerProtocol.swift
+++ b/FetchRequests/Sources/Controller/FetchedResultsControllerProtocol.swift
@@ -32,8 +32,8 @@ public protocol FetchedResultsControllerProtocol: DoublyObservableObject {
 
     var associatedFetchSize: Int { get set }
 
-    var sortDescriptors: [NSSortDescriptor] { get }
     var sectionNameKeyPath: SectionNameKeyPath? { get }
+    var sortDescriptors: [NSSortDescriptor] { get }
 
     func performFetch(completion: @escaping () -> Void)
     func resort(using newSortDescriptors: [NSSortDescriptor], completion: @escaping () -> Void)
@@ -54,7 +54,7 @@ public extension FetchedResultsControllerProtocol {
     }
 
     internal func idealSectionIndex(forSectionName name: String) -> Int {
-        guard let descriptor = sortDescriptors.first else {
+        guard let descriptor = sortDescriptors.first, sectionNameKeyPath != nil else {
             return 0
         }
 
@@ -67,7 +67,7 @@ public extension FetchedResultsControllerProtocol {
         }
     }
 
-    internal func idealObjectIndex(for object: FetchedObject, inArray array: [FetchedObject]) -> Int {
+    func idealObjectIndex(for object: FetchedObject, inArray array: [FetchedObject]) -> Int {
         guard !sortDescriptors.isEmpty else {
             return array.endIndex
         }

--- a/FetchRequests/Sources/FetchableObject.swift
+++ b/FetchRequests/Sources/FetchableObject.swift
@@ -23,9 +23,7 @@ public protocol RawDataRepresentable {
 }
 
 /// A class of types that should be fetchable via FetchRequests
-public protocol FetchableObjectProtocol: AnyObject, Identifiable, RawDataRepresentable
-    where ID: Comparable
-{
+public protocol FetchableObjectProtocol: NSObjectProtocol, Identifiable, RawDataRepresentable {
     /// Has this object been marked as deleted?
     var isDeleted: Bool { get }
 

--- a/FetchRequests/Sources/OrderedSetCompat.swift
+++ b/FetchRequests/Sources/OrderedSetCompat.swift
@@ -128,7 +128,7 @@ extension OrderedSet: SetAlgebra {
             return (true, newMember)
         }
 
-        // returns (false, oldMember)
+        // This should return (false, oldMember)
         return unordered.insert(newMember)
     }
 

--- a/FetchRequests/Sources/OrderedSetCompat.swift
+++ b/FetchRequests/Sources/OrderedSetCompat.swift
@@ -20,6 +20,8 @@ struct OrderedSet<Element: Hashable> {
     private(set) var elements: [Element]
     private(set) var unordered: Set<Element>
 
+    #warning("Make a time efficient firstIndex and lastIndex")
+
     init() {
         elements = []
         unordered = []

--- a/FetchRequests/Sources/OrderedSetCompat.swift
+++ b/FetchRequests/Sources/OrderedSetCompat.swift
@@ -23,7 +23,6 @@ struct OrderedSet<Element: Hashable> {
         }
     }
     private(set) var unordered: Set<Element>
-
     private var indexed: [Element: Int]
 
     init() {

--- a/FetchRequests/Sources/OrderedSetCompat.swift
+++ b/FetchRequests/Sources/OrderedSetCompat.swift
@@ -1,0 +1,252 @@
+//
+//  OrderedSetCompat.swift
+//  OrderedSetCompat
+//
+//  Created by Adam Lickel on 7/20/21.
+//  Copyright © 2021 Speramus Inc. All rights reserved.
+//
+
+#if canImport(Collections)
+
+import Collections
+
+typealias OrderedSet = Collections.OrderedSet
+
+#else
+
+import Foundation
+
+struct OrderedSet<Element: Hashable> {
+    private(set) var elements: [Element]
+    private(set) var unordered: Set<Element>
+
+    init() {
+        elements = []
+        unordered = []
+    }
+
+    init<S: Sequence>(_ sequence: S) where S.Element == Element {
+        self.init()
+        sequence.forEach { insert($0) }
+    }
+}
+
+// MARK: - Capacity
+
+extension OrderedSet {
+    mutating func removeAll(keepingCapacity keepCapacity: Bool = false) {
+        elements.removeAll(keepingCapacity: keepCapacity)
+        unordered.removeAll(keepingCapacity: keepCapacity)
+    }
+
+    mutating func reserveCapacity(_ minimumCapacity: Int) {
+        elements.reserveCapacity(minimumCapacity)
+        unordered.reserveCapacity(minimumCapacity)
+    }
+
+    var capacity: Int {
+        elements.capacity
+    }
+}
+
+// MARK: - Equatable
+
+extension OrderedSet: Equatable {
+    static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.elements == rhs.elements
+    }
+}
+
+// MARK: - Hashable
+
+extension OrderedSet: Hashable {
+    func hash(into hasher: inout Hasher) {
+        elements.hash(into: &hasher)
+    }
+}
+
+// MARK: - CustomStringConvertible
+
+extension OrderedSet: CustomStringConvertible {
+    var description: String {
+        elements.description
+    }
+}
+
+// MARK: - ExpressibleByArrayLiteral
+
+extension OrderedSet: ExpressibleByArrayLiteral {
+    init(arrayLiteral elements: Element...) {
+        self.init(elements)
+    }
+}
+
+// MARK: - SetAlgebra
+
+extension OrderedSet: SetAlgebra {
+    func contains(_ member: Element) -> Bool {
+        unordered.contains(member)
+    }
+
+    @discardableResult
+    mutating func remove(_ member: Element) -> Element? {
+        guard contains(member), let index = elements.firstIndex(of: member) else {
+            return nil
+        }
+        elements.remove(at: index)
+        return unordered.remove(member)
+    }
+
+    @discardableResult
+    mutating func update(with newMember: Element) -> Element? {
+        // Unconditionally update our set, even if our set contains it
+
+        if contains(newMember), let index = elements.firstIndex(of: newMember) {
+            elements[index] = newMember
+            return unordered.update(with: newMember)
+        } else {
+            insert(newMember)
+            return nil
+        }
+    }
+
+    @discardableResult
+    mutating func insert(
+        _ newMember: Element
+    ) -> (inserted: Bool, memberAfterInsert: Element) {
+        // Conditionally update our set, iff our set does not contain it
+
+        guard contains(newMember) else {
+            elements.append(newMember)
+            unordered.insert(newMember)
+            return (true, newMember)
+        }
+
+        // returns (false, oldMember)
+        return unordered.insert(newMember)
+    }
+
+    // Copies
+
+    func union<S: Sequence>(
+        _ other: S
+    ) -> OrderedSet<Element> where S.Element == Element {
+        var copy = self
+        copy.formUnion(other)
+        return copy
+    }
+
+    func intersection<S: Sequence>(
+        _ other: S
+    ) -> OrderedSet<Element> where S.Element == Element {
+        var copy = self
+        copy.formIntersection(other)
+        return copy
+    }
+
+    func symmetricDifference<S: Sequence>(
+        _ other: S
+    ) -> OrderedSet<Element> where S.Element == Element {
+        var copy = self
+        copy.formSymmetricDifference(other)
+        return copy
+    }
+
+    func subtracting<S: Sequence>(
+        _ other: S
+    ) -> OrderedSet<Element> where S.Element == Element {
+        var copy = self
+        copy.subtract(other)
+        return copy
+    }
+
+    // Mutating
+
+    mutating func formUnion<S: Sequence>(
+        _ other: S
+    ) where S.Element == Element {
+        let maxCapacity = elements.count + other.underestimatedCount
+        if capacity < maxCapacity {
+            reserveCapacity(maxCapacity)
+        }
+
+        other.forEach { insert($0) }
+    }
+
+    mutating func formIntersection<S: Sequence>(
+        _ other: S
+    ) where S.Element == Element {
+        unordered.formIntersection(other)
+        elements.removeAll { !unordered.contains($0) }
+    }
+
+    mutating func formSymmetricDifference<S: Sequence>(
+        _ other: S
+    ) where S.Element == Element {
+        let maxCapacity = elements.count + other.underestimatedCount
+        if capacity < maxCapacity {
+            reserveCapacity(maxCapacity)
+        }
+
+        for member in other {
+            if contains(member) {
+                remove(member)
+            } else {
+                insert(member)
+            }
+        }
+    }
+
+    mutating func subtract<S: Sequence>(
+        _ other: S
+    ) where S.Element == Element {
+        unordered.subtract(other)
+        elements.removeAll { !unordered.contains($0) }
+    }
+}
+
+// MARK: - Collection
+
+extension OrderedSet: Collection {
+    var count: Int {
+        elements.count
+    }
+
+    var isEmpty: Bool {
+        elements.isEmpty
+    }
+
+    mutating func removeFirst() -> Element {
+        let firstElement = elements.removeFirst()
+        unordered.remove(firstElement)
+        return firstElement
+    }
+}
+
+// MARK: - BidirectionalCollection
+
+extension OrderedSet: BidirectionalCollection {
+    mutating func removeLast() -> Element {
+        let lastElement = elements.removeLast()
+        unordered.remove(lastElement)
+        return lastElement
+    }
+}
+
+// MARK: - RandomAccessCollection
+
+extension OrderedSet: RandomAccessCollection {
+    var startIndex: Int {
+        elements.startIndex
+    }
+
+    var endIndex: Int {
+        elements.endIndex
+    }
+
+    subscript(position: Int) -> Element {
+        elements[position]
+    }
+}
+
+#endif

--- a/FetchRequests/Tests/Controllers/CollapsibleSectionsFetchedResultsControllerTestCase.swift
+++ b/FetchRequests/Tests/Controllers/CollapsibleSectionsFetchedResultsControllerTestCase.swift
@@ -497,18 +497,15 @@ extension CollapsibleSectionsFetchedResultsControllerTestCase {
 
             return object
         }
-        let sortedSecondaryObjects = secondaryObjects.sorted(by: controller.sortDescriptors)
-        let sortedSecondaryObjectIDs = sortedSecondaryObjects.map { $0.id }
 
         try! performFetch(secondaryObjects)
 
         XCTAssertEqual(controller.fetchedIDs.count, secondaryObjectIDs.count)
-        XCTAssertEqual(controller.fetchedIDs, sortedSecondaryObjectIDs)
         XCTAssertEqual(controller.sections.count, 1)
-        XCTAssertEqual(controller.sections[0].allFetchedIDs, sortedSecondaryObjectIDs)
+        XCTAssertEqual(controller.sections[0].allFetchedIDs, ["9", "0", "2", "1", "4"])
 
-        XCTAssertEqual(controller.tags, [0, 1, 2, 7, 3])
-        XCTAssertEqual(controller.sections[0].allTags, [0, 1, 2, 7, 3])
+        XCTAssertEqual(controller.tags, [3, 0, 2, 6, 7])
+        XCTAssertEqual(controller.sections[0].allTags, [3, 0, 2, 6, 7])
     }
 
     func testBasicFetchWithSortDescriptors() {
@@ -619,13 +616,13 @@ extension CollapsibleSectionsFetchedResultsControllerTestCase {
 
         try! performFetch(secondaryObjects)
 
-        XCTAssertEqual(controller.fetchedIDs, ["a", "z", "c", "b", "d"])
+        XCTAssertEqual(controller.fetchedIDs, ["z", "a", "c", "b", "d"])
         XCTAssertEqual(controller.sections.count, 2)
-        XCTAssertEqual(controller.sections[0].allFetchedIDs, ["a", "z"])
+        XCTAssertEqual(controller.sections[0].allFetchedIDs, ["z", "a"])
         XCTAssertEqual(controller.sections[1].allFetchedIDs, ["c", "b", "d"])
 
-        XCTAssertEqual(controller.tags, [0, 4, 6, 1, 2])
-        XCTAssertEqual(controller.sections[0].allTags, [0, 4])
+        XCTAssertEqual(controller.tags, [4, 0, 6, 1, 2])
+        XCTAssertEqual(controller.sections[0].allTags, [4, 0])
         XCTAssertEqual(controller.sections[1].allTags, [6, 1, 2])
     }
 
@@ -1069,9 +1066,9 @@ extension CollapsibleSectionsFetchedResultsControllerTestCase {
 
         try! performFetch(objects)
 
-        XCTAssertEqual(controller.fetchedIDs, ["a", "z", "b", "c", "d"])
+        XCTAssertEqual(controller.fetchedIDs, ["z", "a", "b", "c", "d"])
         XCTAssertEqual(controller.sections.count, 3)
-        XCTAssertEqual(controller.sections[0].allFetchedIDs, ["a", "z"])
+        XCTAssertEqual(controller.sections[0].allFetchedIDs, ["z", "a"])
         XCTAssertEqual(controller.sections[1].allFetchedIDs, ["b"])
         XCTAssertEqual(controller.sections[2].allFetchedIDs, ["c", "d"])
 
@@ -1079,13 +1076,13 @@ extension CollapsibleSectionsFetchedResultsControllerTestCase {
 
         changeEvents.removeAll()
 
-        getObjectAtIndex(1, withObjectID: "z").sectionName = "a"
+        getObjectAtIndex(1, withObjectID: "a").sectionName = "a"
 
         XCTAssert(changeEvents.isEmpty)
 
-        XCTAssertEqual(controller.fetchedIDs, ["a", "z", "b", "c", "d"])
+        XCTAssertEqual(controller.fetchedIDs, ["z", "a", "b", "c", "d"])
         XCTAssertEqual(controller.sections.count, 3)
-        XCTAssertEqual(controller.sections[0].allFetchedIDs, ["a", "z"])
+        XCTAssertEqual(controller.sections[0].allFetchedIDs, ["z", "a"])
         XCTAssertEqual(controller.sections[1].allFetchedIDs, ["b"])
         XCTAssertEqual(controller.sections[2].allFetchedIDs, ["c", "d"])
     }

--- a/FetchRequests/Tests/Controllers/FetchedResultsControllerTestCase.swift
+++ b/FetchRequests/Tests/Controllers/FetchedResultsControllerTestCase.swift
@@ -138,18 +138,15 @@ class FetchedResultsControllerTestCase: XCTestCase, FetchedResultsControllerTest
 
             return object
         }
-        let sortedSecondaryObjects = secondaryObjects.sorted(by: controller.sortDescriptors)
-        let sortedSecondaryObjectIDs = sortedSecondaryObjects.map { $0.id }
 
         try! performFetch(secondaryObjects)
 
         XCTAssertEqual(controller.fetchedIDs.count, secondaryObjectIDs.count)
-        XCTAssertEqual(controller.fetchedIDs, sortedSecondaryObjectIDs)
         XCTAssertEqual(controller.sections.count, 1)
-        XCTAssertEqual(controller.sections[0].fetchedIDs, sortedSecondaryObjectIDs)
+        XCTAssertEqual(controller.sections[0].fetchedIDs, ["z", "a", "c", "b", "d"])
 
-        XCTAssertEqual(controller.tags, [0, 1, 2, 7, 3])
-        XCTAssertEqual(controller.sections[0].tags, [0, 1, 2, 7, 3])
+        XCTAssertEqual(controller.tags, [3, 0, 2, 6, 7])
+        XCTAssertEqual(controller.sections[0].tags, [3, 0, 2, 6, 7])
     }
 
     func testBasicFetchWithSortDescriptors() {
@@ -261,13 +258,13 @@ extension FetchedResultsControllerTestCase {
 
         try! performFetch(secondaryObjects)
 
-        XCTAssertEqual(controller.fetchedIDs, ["a", "z", "c", "b", "d"])
+        XCTAssertEqual(controller.fetchedIDs, ["z", "a", "c", "b", "d"])
         XCTAssertEqual(controller.sections.count, 2)
-        XCTAssertEqual(controller.sections[0].fetchedIDs, ["a", "z"])
+        XCTAssertEqual(controller.sections[0].fetchedIDs, ["z", "a"])
         XCTAssertEqual(controller.sections[1].fetchedIDs, ["c", "b", "d"])
 
-        XCTAssertEqual(controller.tags, [0, 4, 6, 1, 2])
-        XCTAssertEqual(controller.sections[0].tags, [0, 4])
+        XCTAssertEqual(controller.tags, [4, 0, 6, 1, 2])
+        XCTAssertEqual(controller.sections[0].tags, [4, 0])
         XCTAssertEqual(controller.sections[1].tags, [6, 1, 2])
     }
 
@@ -713,9 +710,9 @@ extension FetchedResultsControllerTestCase {
 
         try! performFetch(objects)
 
-        XCTAssertEqual(controller.fetchedIDs, ["a", "z", "b", "c", "d"])
+        XCTAssertEqual(controller.fetchedIDs, ["z", "a", "b", "c", "d"])
         XCTAssertEqual(controller.sections.count, 3)
-        XCTAssertEqual(controller.sections[0].fetchedIDs, ["a", "z"])
+        XCTAssertEqual(controller.sections[0].fetchedIDs, ["z", "a"])
         XCTAssertEqual(controller.sections[1].fetchedIDs, ["b"])
         XCTAssertEqual(controller.sections[2].fetchedIDs, ["c", "d"])
 
@@ -723,13 +720,13 @@ extension FetchedResultsControllerTestCase {
 
         changeEvents.removeAll()
 
-        getObjectAtIndex(1, withObjectID: "z").sectionName = "a"
+        getObjectAtIndex(1, withObjectID: "a").sectionName = "a"
 
         XCTAssert(changeEvents.isEmpty)
 
-        XCTAssertEqual(controller.fetchedIDs, ["a", "z", "b", "c", "d"])
+        XCTAssertEqual(controller.fetchedIDs, ["z", "a", "b", "c", "d"])
         XCTAssertEqual(controller.sections.count, 3)
-        XCTAssertEqual(controller.sections[0].fetchedIDs, ["a", "z"])
+        XCTAssertEqual(controller.sections[0].fetchedIDs, ["z", "a"])
         XCTAssertEqual(controller.sections[1].fetchedIDs, ["b"])
         XCTAssertEqual(controller.sections[2].fetchedIDs, ["c", "d"])
     }

--- a/FetchRequests/Tests/Controllers/PaginatingFetchedResultsControllerTestCase.swift
+++ b/FetchRequests/Tests/Controllers/PaginatingFetchedResultsControllerTestCase.swift
@@ -138,6 +138,9 @@ class PaginatingFetchedResultsControllerTestCase: XCTestCase, FetchedResultsCont
     func testPaginationDoesNotDisableInserts() {
         controller = PaginatingFetchedResultsController(
             request: createFetchRequest(),
+            sortDescriptors: [
+                NSSortDescriptor(keyPath: \FetchedObject.id, ascending: true),
+            ],
             debounceInsertsAndReloads: false
         )
         controller.setDelegate(self)

--- a/FetchRequests/Tests/Controllers/PausableFetchedResultsControllerTestCase.swift
+++ b/FetchRequests/Tests/Controllers/PausableFetchedResultsControllerTestCase.swift
@@ -258,7 +258,7 @@ extension PausableFetchedResultsControllerTestCase {
         controller.isPaused = false
 
         XCTAssertTrue(changeEvents.isEmpty)
-        XCTAssertEqual(controller.sections[0].fetchedIDs, ["1", "a", "b", "c"])
+        XCTAssertEqual(controller.sections[0].fetchedIDs, ["a", "b", "c", "1"])
     }
 }
 

--- a/FetchRequests/Tests/Controllers/PausableFetchedResultsControllerTestCase.swift
+++ b/FetchRequests/Tests/Controllers/PausableFetchedResultsControllerTestCase.swift
@@ -200,7 +200,7 @@ class PausableFetchedResultsControllerTestCase: XCTestCase, FetchedResultsContro
 
         let effectiveSortDescriptorKeys = [
             #selector(getter: TestObject.sectionName),
-            #selector(getter: TestObject.id),
+            NSSelectorFromString("self"),
         ].map { $0.description }
 
         try! performFetch(["a", "b", "c"])

--- a/Package.swift
+++ b/Package.swift
@@ -16,9 +16,15 @@ let package = Package(
             targets: ["FetchRequests"]
         ),
     ],
+    dependencies: [
+        .package(url: "https://github.com/apple/swift-collections", from: "0.0.4"),
+    ],
     targets: [
         .target(
             name: "FetchRequests",
+            dependencies: [
+                .product(name: "Collections", package: "swift-collections"),
+            ],
             path: "FetchRequests",
             exclude: ["Tests"]
         ),

--- a/Package@swift-5.5.swift
+++ b/Package@swift-5.5.swift
@@ -17,9 +17,15 @@ let package = Package(
             targets: ["FetchRequests"]
         ),
     ],
+    dependencies: [
+        .package(url: "https://github.com/apple/swift-collections", from: "0.0.4"),
+    ],
     targets: [
         .target(
             name: "FetchRequests",
+            dependencies: [
+                .product(name: "Collections", package: "swift-collections"),
+            ],
             path: "FetchRequests",
             exclude: ["Tests"]
         ),


### PR DESCRIPTION
Because of CocoaPods, I need to bundle a cheap and dirty version of OrderedSet.
In theory I could probably use git submodules, but I didn't want to go down that route.

This uses the `fetchedObjectIDs` as the source of truth for what order the objects were inserted into the controller.
Any sorting uses that ordered set to determine the "stable" fallback sort position.